### PR TITLE
Add theme toggle

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,19 +1,23 @@
 ---
 
 ---
+import ThemeToggle from "./ThemeToggle.astro";
 
 <nav
   id="navbar"
-  class="fixed top-0 left-0 w-full text-white bg-neutral-900/60 backdrop-blur-md border-b border-neutral-800 shadow-md rounded-b-xl z-50 transition-transform duration-300"
+  class="fixed top-0 left-0 w-full bg-white/70 dark:bg-neutral-900/60 text-neutral-900 dark:text-white backdrop-blur-md border-b border-neutral-200 dark:border-neutral-800 shadow-md rounded-b-xl z-50 transition-transform duration-300"
 >
   <div class="max-w-6xl mx-auto px-4 py-3 flex justify-between items-center">
     <a href="https://hupog.dev" class="text-lg font-bold">hupog.dev</a>
-    <ul class="flex space-x-6 text-sm">
-      <li><a href="#inicio" class="hover:underline">Inicio</a></li>
-      <li><a href="#projects" class="hover:underline">Proyectos</a></li>
-      <li><a href="#experience" class="hover:underline">Experiencia</a></li>
-      <li><a href="#contact" class="hover:underline">Contacto</a></li>
-    </ul>
+    <div class="flex items-center space-x-4">
+      <ul class="flex space-x-6 text-sm">
+        <li><a href="#inicio" class="hover:underline">Inicio</a></li>
+        <li><a href="#projects" class="hover:underline">Proyectos</a></li>
+        <li><a href="#experience" class="hover:underline">Experiencia</a></li>
+        <li><a href="#contact" class="hover:underline">Contacto</a></li>
+      </ul>
+      <ThemeToggle />
+    </div>
   </div>
 
   <script>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,23 @@
+---
+---
+<button id="theme-toggle" class="p-2 rounded-md border border-neutral-600">
+  <span class="sr-only">Toggle dark mode</span>
+  🌓
+</button>
+<script>
+const html = document.documentElement;
+const stored = localStorage.getItem('theme');
+if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+  html.classList.add('dark');
+}
+const btn = document.getElementById('theme-toggle');
+btn?.addEventListener('click', () => {
+  if (html.classList.contains('dark')) {
+    html.classList.remove('dark');
+    localStorage.setItem('theme', 'light');
+  } else {
+    html.classList.add('dark');
+    localStorage.setItem('theme', 'dark');
+  }
+});
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,7 +2,11 @@
 
 /* Puedes añadir estilos globales aquí */
 body {
-  @apply bg-neutral-950 text-white font-sans;
+  @apply bg-white text-neutral-900 font-sans;
+}
+
+.dark body {
+  @apply bg-neutral-950 text-white;
 }
 
 ::selection {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  darkMode: 'class',
+  content: ['./src/**/*.{astro,html,js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add new ThemeToggle component
- add dark mode toggle in Navbar
- support dark-mode class in Tailwind
- adjust global styles for light/dark themes

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611c4f2a9c8327a3687661d7917762