### PR TITLE
Add language switcher and i18n

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -1,24 +1,24 @@
 ---
-
+const { t } = Astro.props;
 ---
 
 <section id="contact" class="min-h-screen px-6 py-20">
   <div class="max-w-5xl mx-auto text-center">
-    <h2 class="text-4xl font-bold mb-4">Contacto</h2>
+    <h2 class="text-4xl font-bold mb-4">{t.contact.title}</h2>
     <p class="text-gray-400 mb-10">
-      ¿Quieres colaborar? Completa el formulario o escríbeme directamente.
+      {t.contact.description}
     </p>
 
     <div class="mb-10 space-y-2">
       <p>
-        <strong>Email:</strong>
+        <strong>{t.contact.emailLabel}</strong>
         <a
           href="mailto:contacto@hupog.dev"
           class="text-blue-400 hover:underline">contacto@hupog.dev</a
         >
       </p>
       <p>
-        <strong>GitHub:</strong>
+        <strong>{t.contact.githubLabel}</strong>
         <a
           href="https://github.com/hupog"
           class="text-blue-400 hover:underline"
@@ -26,7 +26,7 @@
         >
       </p>
       <p>
-        <strong>LinkedIn:</strong>
+        <strong>{t.contact.linkedinLabel}</strong>
         <a
           href="https://www.linkedin.com/in/hugo-gonz%C3%A1lez-portilla"
           class="text-blue-400 hover:underline"
@@ -41,7 +41,7 @@
       class="p-6 rounded-2xl bg-neutral-900/40 backdrop-blur shadow-lg text-left max-w-xl mx-auto space-y-4"
     >
       <div>
-        <label for="name" class="block text-sm font-medium">Nombre</label>
+        <label for="name" class="block text-sm font-medium">{t.contact.nameLabel}</label>
         <input
           type="text"
           name="name"
@@ -51,7 +51,7 @@
       </div>
 
       <div>
-        <label for="email" class="block text-sm font-medium">Correo</label>
+        <label for="email" class="block text-sm font-medium">{t.contact.emailField}</label>
         <input
           type="email"
           name="email"
@@ -61,7 +61,7 @@
       </div>
 
       <div>
-        <label for="message" class="block text-sm font-medium">Mensaje</label>
+        <label for="message" class="block text-sm font-medium">{t.contact.messageLabel}</label>
         <textarea
           name="message"
           required
@@ -75,7 +75,7 @@
           type="submit"
           class="mt-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded shadow transition-colors"
         >
-          Enviar
+          {t.contact.submit}
         </button>
       </div>
     </form>

--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -1,33 +1,28 @@
+---
+const { t } = Astro.props;
+---
 <section class="px-6 py-20" id="experience">
   <div class="max-w-6xl mx-auto">
-    <h2 class="text-4xl font-bold mb-8 text-center">Experiencia</h2>
+    <h2 class="text-4xl font-bold mb-8 text-center">{t.experience.title}</h2>
     <div
       class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 place-items-center"
     >
       <div
         class="bg-neutral-900/40 backdrop-blur p-6 rounded-2xl shadow-md text-left hover:scale-[1.02] hover:bg-neutral-900/60 transition-all duration-300 hover:shadow-lg md:col-start-1 md:col-end-3 lg:col-start-2 lg:col-end-3"
       >
-      <div class="flex items-center gap-4 mb-4">
-        <img
-          src="/logo-nune.png"
-          alt="Logo Nunegal Consulting"
-          class="w-24 h-24 object-contain"
-        />
-        <div>
-          <h3 class="text-xl font-bold">Nunegal Consulting</h3>
-          <p class="text-sm text-gray-400">
-            Remoto · A Coruña · Jun 2024 – Dic 2024
-          </p>
+        <div class="flex items-center gap-4 mb-4">
+          <img
+            src="/logo-nune.png"
+            alt="Logo Nunegal Consulting"
+            class="w-24 h-24 object-contain"
+          />
+          <div>
+            <h3 class="text-xl font-bold">{t.experience.nunegal.company}</h3>
+            <p class="text-sm text-gray-400">{t.experience.nunegal.location}</p>
+          </div>
         </div>
+        <p class="text-justify">{t.experience.nunegal.description}</p>
       </div>
-      <p class="text-justify">
-        Durante mis prácticas en Nunegal Consulting formé parte de un equipo de
-        desarrollo web, donde trabajé con tecnologías como <strong
-          >Java, Spring Boot y Thymeleaf</strong
-        > para construir aplicaciones empresariales. Esta experiencia me permitió
-        familiarizarme con el trabajo en entornos ágiles, control de versiones con
-        Git y el desarrollo de soluciones orientadas a cliente.
-      </p>
     </div>
   </div>
 </section>

--- a/src/components/Intro.astro
+++ b/src/components/Intro.astro
@@ -1,20 +1,16 @@
 ---
-
+const { t } = Astro.props;
 ---
 
 <section
-  id="inicio"
+  id="intro"
   class="relative min-h-screen flex items-center justify-center overflow-hidden px-4"
 >
   <div class="absolute inset-0 -z-10"></div>
 
   <div class="z-10 text-center max-w-4xl mx-auto">
-    <h1 class="text-5xl font-extrabold mb-6">Hola, soy Hugo González Portilla</h1>
-    <p class="text-xl text-gray-300">
-      Recién Graduado en Ingeniería Informática, preparado para dar el salto al
-      mundo profesional. Busco nuevos retos que me permitan seguir aprendiendo,
-      crecer en nuevos entornos y aportar desde el primer día.
-    </p>
+    <h1 class="text-5xl font-extrabold mb-6">{t.intro.title}</h1>
+    <p class="text-xl text-gray-300">{t.intro.description}</p>
   </div>
 
   <script>

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -1,0 +1,19 @@
+---
+const { lang } = Astro.props;
+---
+
+<select id="lang-select" class="bg-neutral-900 text-white border border-neutral-700 p-1 rounded" value={lang}>
+  <option value="es" selected={lang === 'es'}>ES</option>
+  <option value="en" selected={lang === 'en'}>EN</option>
+</select>
+
+<script>
+  const select = document.getElementById('lang-select');
+  select.addEventListener('change', (e) => {
+    const newLang = e.target.value;
+    localStorage.setItem('lang', newLang);
+    const url = new URL(window.location.href);
+    url.searchParams.set('lang', newLang);
+    window.location.href = url;
+  });
+</script>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,5 +1,6 @@
 ---
-
+import LanguageSwitcher from "./LanguageSwitcher.astro";
+const { t, lang } = Astro.props;
 ---
 
 <nav
@@ -9,11 +10,12 @@
   <div class="max-w-6xl mx-auto px-4 py-3 flex justify-between items-center">
     <a href="https://hupog.dev" class="text-lg font-bold">hupog.dev</a>
     <ul class="flex space-x-6 text-sm">
-      <li><a href="#inicio" class="hover:underline">Inicio</a></li>
-      <li><a href="#projects" class="hover:underline">Proyectos</a></li>
-      <li><a href="#experience" class="hover:underline">Experiencia</a></li>
-      <li><a href="#contact" class="hover:underline">Contacto</a></li>
+      <li><a href="#intro" class="hover:underline">{t.navbar.home}</a></li>
+      <li><a href="#projects" class="hover:underline">{t.navbar.projects}</a></li>
+      <li><a href="#experience" class="hover:underline">{t.navbar.experience}</a></li>
+      <li><a href="#contact" class="hover:underline">{t.navbar.contact}</a></li>
     </ul>
+    <LanguageSwitcher lang={lang} />
   </div>
 
   <script>

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -1,13 +1,11 @@
 ---
-
+const { t } = Astro.props;
 ---
 
 <section id="projects" class="px-6 py-20">
   <div class="max-w-6xl mx-auto">
-    <h2 class="text-4xl font-bold mb-6 text-center">Proyectos</h2>
-    <p class="text-gray-400 text-center mb-12 max-w-xl mx-auto">
-      Algunos de los proyectos en los que he trabajado. Más por venir...
-    </p>
+    <h2 class="text-4xl font-bold mb-6 text-center">{t.projects.title}</h2>
+    <p class="text-gray-400 text-center mb-12 max-w-xl mx-auto">{t.projects.description}</p>
 
     <div
       class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 place-items-center"
@@ -27,12 +25,8 @@
               class="w-24 h-24 object-contain"
             />
           </div>
-          <h3 class="text-center text-xl font-semibold mb-2">Restvisor</h3>
-          <p class="text-justify text-white-400 text-sm">
-            Aplicación Web basada en React pensada para la gestión integral de
-            un restaurante, con comunicación entre las distintas partes de este
-            y con una interfaz sencilla y reutilizable.
-          </p>
+          <h3 class="text-center text-xl font-semibold mb-2">{t.projects.restvisor.name}</h3>
+          <p class="text-justify text-white-400 text-sm">{t.projects.restvisor.description}</p>
         </div>
       </a>
     </div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,39 @@
+{
+  "navbar": {
+    "home": "Home",
+    "projects": "Projects",
+    "experience": "Experience",
+    "contact": "Contact"
+  },
+  "intro": {
+    "title": "Hi, I'm Hugo González Portilla",
+    "description": "Recent Computer Engineering graduate ready to jump into the professional world. I'm looking for new challenges that will allow me to keep learning, grow in new environments and contribute from day one."
+  },
+  "projects": {
+    "title": "Projects",
+    "description": "Some of the projects I've worked on. More coming soon...",
+    "restvisor": {
+      "name": "Restvisor",
+      "description": "React-based web application designed for comprehensive restaurant management, enabling communication between the different areas and providing a simple, reusable interface."
+    }
+  },
+  "experience": {
+    "title": "Experience",
+    "nunegal": {
+      "company": "Nunegal Consulting",
+      "location": "Remote · A Coruña · Jun 2024 – Dec 2024",
+      "description": "During my internship at Nunegal Consulting I was part of a web development team working with technologies such as Java, Spring Boot and Thymeleaf to build enterprise applications. This experience allowed me to become familiar with agile environments, version control with Git and customer-oriented solution development."
+    }
+  },
+  "contact": {
+    "title": "Contact",
+    "description": "Want to collaborate? Fill out the form or reach out to me directly.",
+    "emailLabel": "Email:",
+    "githubLabel": "GitHub:",
+    "linkedinLabel": "LinkedIn:",
+    "nameLabel": "Name",
+    "emailField": "Email",
+    "messageLabel": "Message",
+    "submit": "Send"
+  }
+}

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,0 +1,39 @@
+{
+  "navbar": {
+    "home": "Inicio",
+    "projects": "Proyectos",
+    "experience": "Experiencia",
+    "contact": "Contacto"
+  },
+  "intro": {
+    "title": "Hola, soy Hugo González Portilla",
+    "description": "Recién Graduado en Ingeniería Informática, preparado para dar el salto al mundo profesional. Busco nuevos retos que me permitan seguir aprendiendo, crecer en nuevos entornos y aportar desde el primer día."
+  },
+  "projects": {
+    "title": "Proyectos",
+    "description": "Algunos de los proyectos en los que he trabajado. Más por venir...",
+    "restvisor": {
+      "name": "Restvisor",
+      "description": "Aplicación Web basada en React pensada para la gestión integral de un restaurante, con comunicación entre las distintas partes de este y con una interfaz sencilla y reutilizable."
+    }
+  },
+  "experience": {
+    "title": "Experiencia",
+    "nunegal": {
+      "company": "Nunegal Consulting",
+      "location": "Remoto · A Coruña · Jun 2024 – Dic 2024",
+      "description": "Durante mis prácticas en Nunegal Consulting formé parte de un equipo de desarrollo web, donde trabajé con tecnologías como Java, Spring Boot y Thymeleaf para construir aplicaciones empresariales. Esta experiencia me permitió familiarizarme con el trabajo en entornos ágiles, control de versiones con Git y el desarrollo de soluciones orientadas a cliente."
+    }
+  },
+  "contact": {
+    "title": "Contacto",
+    "description": "¿Quieres colaborar? Completa el formulario o escríbeme directamente.",
+    "emailLabel": "Email:",
+    "githubLabel": "GitHub:",
+    "linkedinLabel": "LinkedIn:",
+    "nameLabel": "Nombre",
+    "emailField": "Correo",
+    "messageLabel": "Mensaje",
+    "submit": "Enviar"
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,9 +5,15 @@ import Intro from "../components/Intro.astro";
 import Projects from "../components/Projects.astro";
 import Contact from "../components/Contact.astro";
 import Experience from "../components/Experience.astro";
+import es from "../i18n/es.json";
+import en from "../i18n/en.json";
+
+const urlLang = Astro.url.searchParams.get('lang');
+let lang = urlLang || 'es';
+const t = lang === 'en' ? en : es;
 ---
 
-<html lang="es">
+<html lang={lang}>
   <head>
     <meta charset="UTF-8" />
     <title>.dev</title>
@@ -16,12 +22,22 @@ import Experience from "../components/Experience.astro";
   <body
     class="animate-gradient bg-gradient-to-br from-blue-700 via-green-800 to-black"
   >
-    <Navbar />
+    <Navbar t={t} lang={lang} />
     <main>
-      <section id="intro"><Intro /></section>
-      <section id="projects"><Projects /></section>
-      <section id="experience"><Experience /></section>
-      <section id="contact"><Contact /></section>
+      <Intro t={t} />
+      <Projects t={t} />
+      <Experience t={t} />
+      <Contact t={t} />
+    <script>
+      const stored = localStorage.getItem("lang");
+      if(stored && !window.location.search.includes("lang=")){
+        const url = new URL(window.location.href);
+        url.searchParams.set("lang", stored);
+        window.location.replace(url);
+      } else if(!stored){
+        localStorage.setItem("lang", lang);
+      }
+    </script>
     </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add language switcher component
- add English and Spanish translation files
- load language translations on pages and components
- update page elements to use translated strings
- fix intro section id and remove duplicate wrapper sections

## Testing
- `npm run build` *(fails: astro not found)*


------
https://chatgpt.com/codex/tasks/task_e_68611c40693c8327a6d806fd3f8401bc